### PR TITLE
Bug Fix: Allow HTTP for Tables API requests 

### DIFF
--- a/tulip_tables.js
+++ b/tulip_tables.js
@@ -17,7 +17,7 @@ module.exports = function (RED) {
     // Set node properties
     this.name = config.name;
     this.apiAuth = RED.nodes.getNode(config.apiAuth);
-    this.agent = new httpLibs[apiAuth.protocol].Agent({
+    this.agent = new httpLibs[this.apiAuth.protocol].Agent({
       keepAlive: config.keepAlive,
       keepAliveMsecs: config.keepAliveMsecs,
     });


### PR DESCRIPTION
Followup on [this PR](https://github.com/tulip/node-red-tulip-api/pull/2) that adds ability to select `http` for the protocol for API requests in the machine API.

Currently, if using the Tables API, you can select `http` as the protocol but it will ignore this and still use `https` when sending the request. This PR fixes this bug; now when `http` is selected a Tables API request will send the request using `http`.