### PR TITLE
Remove request as dependency 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tulip/node-red-tulip-api",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Node-RED nodes for sending data to the Tulip API",
   "main": "index.js",
   "node-red": {
@@ -30,7 +30,5 @@
     "url": "https://github.com/tulip/node-red-tulip-api/issues"
   },
   "homepage": "https://github.com/tulip/node-red-tulip-api#readme",
-  "dependencies": {
-    "request": "^2.87.0"
-  }
+  "dependencies": {}
 }

--- a/tulip_machine_attribute.html
+++ b/tulip_machine_attribute.html
@@ -38,10 +38,10 @@
         } else {
           $('#div-node-input-keepAliveMsecs').hide();
         }
-      }
+      };
       updateKeepAlive();
       $('#node-input-keepAlive').change(() => {
-        updateKeepAlive()
+        updateKeepAlive();
       });
 
       // Generate typed input fields
@@ -64,19 +64,20 @@
     <input type="text" id="node-input-name" placeholder="Name" />
   </div>
   <div class="form-row">
-    <label for="node-input-apiAuth"
-      ><i class="fa fa-user-circle"></i> Tulip API Authentication</label
-    >
+    <label><i class="fa fa-user-circle"></i> Tulip API Authentication</label>
     <input id="node-input-apiAuth" />
   </div>
   <div class="form-row">
-    <label for="node-input-deviceInfo"><i class="fa fa-clipboard"></i> Device Info</label>
+    <label for="node-input-deviceInfo"
+      ><i class="fa fa-clipboard"></i> Device Info</label
+    >
     <input type="text" id="node-input-deviceInfo" />
   </div>
   <div class="form-tips">
-    <b>Tip:</b> This field can be copy-pasted from your Tulip factory instance. Navigate to Shop
-    Floor > Machines, select your machine from the Machine Library, and click the clipboard icon
-    next to the target Machine Attribute to copy-paste its device info.
+    <b>Tip:</b> This field can be copy-pasted from your Tulip factory instance.
+    Navigate to Shop Floor > Machines, select your machine from the Machine
+    Library, and click the clipboard icon next to the target Machine Attribute
+    to copy-paste its device info.
   </div>
 
   <hr />
@@ -84,20 +85,29 @@
   <div class="form-row">
     <h4>Advanced</h4>
   </div>
-  <div class='form-row'>
-    <label for='node-input-keepAlive'> HTTP Options</label>
+  <div class="form-row">
+    <label for="node-input-keepAlive"> HTTP Options</label>
     <input
-      type='checkbox'
-      id='node-input-keepAlive'
-      autocomplete='off'
-      style='margin-left:10px; vertical-align:top; width:auto'
+      type="checkbox"
+      id="node-input-keepAlive"
+      autocomplete="off"
+      style="margin-left:10px; vertical-align:top; width:auto"
     />
-    <label for='node-input-keepAlive' style='width:auto'>Enable Connection Keep-Alive</label>
+    <label for="node-input-keepAlive" style="width:auto"
+      >Enable Connection Keep-Alive</label
+    >
   </div>
-  <div class='form-row' id='div-node-input-keepAliveMsecs' hidden>
+  <div class="form-row" id="div-node-input-keepAliveMsecs" hidden>
     <label for="node-input-keepAliveMsecs">&nbsp;</label>
     <span style="width:auto">Keep-Alive Initial Delay (ms)</span>
-    <input type='number' min=0 step=1 id='node-input-keepAliveMsecs' value=10000 style="width:auto">
+    <input
+      type="number"
+      min="0"
+      step="1"
+      id="node-input-keepAliveMsecs"
+      value="10000"
+      style="width:auto"
+    />
   </div>
   <div class="form-row">
     <label for="node-input-payloadSource"> Attribute Source</label>
@@ -176,21 +186,22 @@
   </p>
 
   <p>
-    For basic operation, only <code>msg.payload</code> needs to be passed into the node,
-    and the <code>deviceInfo</code> can be copy-pasted into "Device Info" from the Machine page on your factory instance.
+    For basic operation, only <code>msg.payload</code> needs to be passed into the node, and the <code>deviceInfo</code> can be
+    copy-pasted into "Device Info" from the Machine page on your factory instance.
   </p>
 
   <h3>Advanced Operation</h3>
   <p>
     For more advanced operation, you can specify the attribute value to come from a source other than <code>msg.payload</code>.
-    Supported sources are: properties of <code>msg</code>, <code>flow</code>, or <code>global</code>; strings; numbers;
-    JSONata expressions; environment variables.
+    Supported sources are: properties of <code>msg</code>, <code>flow</code>, or <code>global</code>; strings; numbers; JSONata
+    expressions; environment variables.
   </p>
   <p>
-    You can also override the properties in the "Device Info" field with <code>msg</code> properties to configure the node to send to different endpoints.
-    Specifically, <code>msg.attributeId</code> will override <code>deviceInfo.attributeId</code>, and <code>msg.machineId</code> will override <code>deviceInfo.machineId</code>.
-    If you override either property with every <code>msg</code>, it is not needed in the "Device Info" field.
-    For example, if every <code>msg</code> has both <code>machineId</code> and <code>attribute</code> set, you can leave "Device Info" as <code>{}</code>.
+    You can also override the properties in the "Device Info" field with <code>msg</code> properties to configure the node to send
+    to different endpoints. Specifically, <code>msg.attributeId</code> will override <code>deviceInfo.attributeId</code>, and
+    <code>msg.machineId</code> will override <code>deviceInfo.machineId</code>. If you override either property with every
+    <code>msg</code>, it is not needed in the "Device Info" field. For example, if every <code>msg</code> has both <code>machineId</code>
+    and <code>attribute</code> set, you can leave "Device Info" as <code>{}</code>.
   </p>
   <p>
     Lastly, you can configure the HTTP agent to use keep-alive by checking "Enable Connection Keep-Alive" (default=<code>true</code>),

--- a/tulip_machine_attribute.html
+++ b/tulip_machine_attribute.html
@@ -64,7 +64,9 @@
     <input type="text" id="node-input-name" placeholder="Name" />
   </div>
   <div class="form-row">
-    <label><i class="fa fa-user-circle"></i> Tulip API Authentication</label>
+    <label for="node-input-apiAuth"
+      ><i class="fa fa-user-circle"></i> Tulip API Authentication</label
+    >
     <input id="node-input-apiAuth" />
   </div>
   <div class="form-row">
@@ -163,8 +165,10 @@
   <h3>Overview</h3>
   <p>
     Each <code>tulip-machine-attribute</code> node is configured to send data to a Tulip Machine API endpoint.
+    This endpoint is unique to a single machine attribute for a single machine on your Tulip factory instance.
     To send data to a given factory instance, you must configure a <code>tulip-api-auth</code> nodde with authentication details.
     The bot used for authentication must have <code>attributes:write</code> permissions.
+
     This authentication node can be shared between <code>tulip-machine-attribute</code> nodes.
   </p>
 

--- a/tulip_machine_attribute.js
+++ b/tulip_machine_attribute.js
@@ -1,14 +1,12 @@
 module.exports = function (RED) {
   'use strict';
 
-  const request = require('request');
   const https = require('https');
   const http = require('http');
   const httpLibs = {
     http,
     https,
-  }
-  const { v4: uuidv4 } = require('uuid');
+  };
 
   // Tulip API node
   function MachineAttrNode(config) {
@@ -20,14 +18,20 @@ module.exports = function (RED) {
     this.deviceInfo = JSON.parse(config.deviceInfo);
     this.payloadSource = config.payloadSource;
     this.payloadType = config.payloadType;
-    this.agent = new httpLibs[apiAuthNode.protocol].Agent({
+    this.apiCredentials = apiAuthNode.credentials;
+    this.factoryUrl = getFactoryUrl(
+      apiAuthNode.protocol,
+      apiAuthNode.hostname,
+      apiAuthNode.port
+    );
+    this.protocol = apiAuthNode.protocol;
+
+    // Use http or https depending on the factory protocol
+    const httpLib = httpLibs[this.protocol];
+    this.agent = new httpLib.Agent({
       keepAlive: config.keepAlive,
       keepAliveMsecs: config.keepAliveMsecs,
     });
-
-    // Properties that depend on auth configuration
-    this.apiCredentials = apiAuthNode.credentials;
-    this.factoryUrl = getFactoryUrl(apiAuthNode.protocol, apiAuthNode.hostname, apiAuthNode.port);
 
     const node = this;
 
@@ -67,35 +71,62 @@ module.exports = function (RED) {
 
       // Configure POST request w/auth
       const options = {
-        url: endpoint,
-        body,
         method: 'POST',
-        headers,
-        auth: {
-          user: node.apiCredentials.apiKey,
-          pass: node.apiCredentials.apiSecret,
-        },
+        auth: `${node.apiCredentials.apiKey}:${node.apiCredentials.apiSecret}`,
         agent: node.agent,
       };
 
-      // Send request
-      request(options, function (err, res, body) {
-        if (err) {
-          done(err);
-        } else {
-          if (res.statusCode < 200 || res.statusCode >= 300) {
-            // Request returns error code
-            node.error(new Error(res.body));
-          }
-          // Forward response as node output
+      // Make the http(s) request
+      const req = httpLib.request(endpoint, options, handler(send, done));
+      setHeaders(req, headers);
+
+      req.write(body);
+      req.on('error', (err) => {
+        done(err);
+      });
+
+      req.end();
+    }
+
+    const setHeaders = function (req, headers) {
+      if (headers) {
+        Object.entries(headers).forEach(([header, val]) => {
+          req.setHeader(header, val);
+        });
+      }
+    };
+
+    // Returns a handler for the HTTP response that passes the body to `send`, and passes
+    // errors to onError
+    const handler = function (send, done) {
+      return (res) => {
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          // Request returns error code
+          node.error(new Error(`Response status code ${res.statusCode}`));
+        }
+
+        let body = '';
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+
+        // At the end of response, pass response body as msg.payload
+        res.on('end', () => {
+          const convertJSON =
+            res.headers['content-type'] &&
+            res.headers['content-type'].includes('application/json');
+
+          // if response is JSON, parse body as JSON
+          const payload = convertJSON ? JSON.parse(body) : body;
           const msg = {
             response: res,
+            payload,
           };
           send(msg);
           done();
-        }
-      });
-    }
+        });
+      };
+    };
 
     function getFactoryUrl(protocol, hostname, port) {
       // start with valid protocol & host
@@ -123,7 +154,7 @@ module.exports = function (RED) {
       // Content-Type set by this node; overrides user value
       if (headers['Content-Type']) {
         node.warn(
-          `Overriding header 'Content-Type'='${headers['Content-Type']}'; must be 'application/json'`,
+          `Overriding header 'Content-Type'='${headers['Content-Type']}'; must be 'application/json'`
         );
       }
       headers['Content-Type'] = 'application/json';
@@ -145,7 +176,10 @@ module.exports = function (RED) {
         if (typeof paramVal != 'string') {
           // msg parameter is invalid
           const paramType = typeof paramVal;
-          throw new Error(`msg.${param} must be string,` + `${paramVal} is of type ${paramType}`);
+          throw new Error(
+            `msg.${param} must be string,` +
+              `${paramVal} is of type ${paramType}`
+          );
         } else {
           // msg has valid parameter
           return paramVal;
@@ -159,7 +193,12 @@ module.exports = function (RED) {
    * Throws an error if the payload is undefined.
    */
   function getPayload(msg, node) {
-    const payload = getTypedData(msg, node, node.payloadType, node.payloadSource);
+    const payload = getTypedData(
+      msg,
+      node,
+      node.payloadType,
+      node.payloadSource
+    );
     if (payload == undefined) {
       throw new Error('payload not defined');
     }
@@ -188,7 +227,11 @@ module.exports = function (RED) {
         return RED.util.evaluateNodeProperty(dataVal, dataType, node, msg);
       } catch (err) {
         // Add detailed error message
-        node.error(new Error(`Error evaluating node property ${dataVal} of type ${dataType}`));
+        node.error(
+          new Error(
+            `Error evaluating node property ${dataVal} of type ${dataType}`
+          )
+        );
         throw err;
       }
     }

--- a/tulip_machine_attribute.js
+++ b/tulip_machine_attribute.js
@@ -80,7 +80,15 @@ module.exports = function (RED) {
       };
 
       // Create, send, handle, and close HTTP request
-      doHttpRequest(httpLib, endpoint, options, body, node.error);
+      doHttpRequest(
+        httpLib,
+        endpoint,
+        options,
+        body,
+        node.error.bind(node),
+        send,
+        done
+      );
     }
 
     function getFactoryUrl(protocol, hostname, port) {

--- a/tulip_tables.html
+++ b/tulip_tables.html
@@ -1,6 +1,6 @@
-<script src='node-red-tulip-edge/js/tulip_tables_common.js'></script>
+<script src="node-red-tulip-edge/js/tulip_tables_common.js"></script>
 
-<script type='text/javascript'>
+<script type="text/javascript">
   const QUERY_TYPES = this.tulip_tables_common.TABLE_QUERY_TYPES;
   RED.nodes.registerType('tulip-tables', {
     category: 'Tulip',
@@ -13,7 +13,7 @@
       apiAuth: {
         value: '',
         type: 'tulip-api-auth',
-        required: true
+        required: true,
       },
       keepAlive: { value: true },
       keepAliveMsecs: { value: 10000 },
@@ -47,13 +47,13 @@
       filters: { value: [] },
       sortOptions: { value: [] },
 
-      body: { value: '{}' } // JSON body
+      body: { value: '{}' }, // JSON body
     },
     paletteLabel: 'tables',
-    label: function() {
+    label: function () {
       return this.name || 'tulip-machine-attribute';
     },
-    oneditprepare: function() {
+    oneditprepare: function () {
       const node = this;
 
       // Whether or not to show keep-alive msecs option
@@ -64,10 +64,10 @@
         } else {
           $('#div-node-input-keepAliveMsecs').hide();
         }
-      }
+      };
       updateKeepAlive();
       $('#node-input-keepAlive').change(() => {
-        updateKeepAlive()
+        updateKeepAlive();
       });
 
       // Create dropdown menu of table query types
@@ -92,7 +92,7 @@
 
       // Set the document to hide/show elements for different query selections
       $(querySelect).data('prevQueryType', node.queryType);
-      $(querySelect).change(function(data) {
+      $(querySelect).change(function (data) {
         const newQueryType = $(this).val();
         const oldQueryType = $(this).data('prevQueryType');
 
@@ -125,8 +125,8 @@
 
       // Show custom sortBy field
       const sortBySelect = document.getElementById('node-input-sortBy');
-      $(sortBySelect).change(function(data) {
-        if  ($(this).val() == 'other') {
+      $(sortBySelect).change(function (data) {
+        if ($(this).val() == 'other') {
           $(`#div-node-input-sortByOther`).show();
         } else {
           $(`#div-node-input-sortByOther`).hide();
@@ -136,34 +136,33 @@
       // Convert JSON inputs to typedInput
       $('#node-input-body').typedInput({
         type: 'json',
-        types: ['json']
+        types: ['json'],
       });
 
       // Adds an editableList widget for the given parameter `p`
       // of the specified type `t`
       function addEditableTypedList(param, paramType) {
-
         // Creates a function to be called when adding a list item
         // for this parameter & type
-        const getAddItem = function() {
-          return function(container, i, data) {
+        const getAddItem = function () {
+          return function (container, i, data) {
             container.css({
               overflow: 'hidden',
-              whiteSpace: 'nowrap'
+              whiteSpace: 'nowrap',
             });
             const row = $('<div/>').appendTo(container);
 
             // Create the TypedInput element
             const typedInputElem = $('<input/>', {
-                class: `node-input-${param}-value`,
-                type: 'text',
-                width: '100%'
-              })
+              class: `node-input-${param}-value`,
+              type: 'text',
+              width: '100%',
+            })
               .appendTo(row)
               .typedInput({
                 default: paramType,
                 types: [paramType],
-                type: paramType
+                type: paramType,
               })
               .typedInput('show');
 
@@ -191,13 +190,15 @@
           scrollOnAdd: true,
           sortable: true,
           removable: true,
-          addItem: getAddItem()
+          addItem: getAddItem(),
         });
 
         // Populate list with current values
         node[param].forEach((v) => {
-          const value = (paramType == 'json') ? JSON.stringify(v) : v;
-          $(`#node-input-${param}-container`).editableList('addItem', { value });
+          const value = paramType == 'json' ? JSON.stringify(v) : v;
+          $(`#node-input-${param}-container`).editableList('addItem', {
+            value,
+          });
         });
       }
 
@@ -206,14 +207,16 @@
       addEditableTypedList('filters', 'json');
       addEditableTypedList('sortOptions', 'json');
     },
-    oneditsave: function() {
+    oneditsave: function () {
       const node = this;
 
       // Saves values in EditableList to the node config
       function saveListValues(param, paramType) {
-        const entries = $(`#node-input-${param}-container`).editableList('items');
+        const entries = $(`#node-input-${param}-container`).editableList(
+          'items'
+        );
         node[param] = [];
-        entries.each(function(e) {
+        entries.each(function (e) {
           // Iterate through list items in UI
           const entry = $(this);
           const entryValue = entry.find(`.node-input-${param}-value`).val();
@@ -239,11 +242,11 @@
       saveListValues('field', 'str');
       saveListValues('filters', 'json');
       saveListValues('sortOptions', 'json');
-    }
+    },
   });
 </script>
 
-<script type='text/html' data-template-name='tulip-tables'>
+<script type="text/html" data-template-name="tulip-tables">
   <div class='form-row'>
     <label for='node-input-name'><i class='fa fa-tag'></i> Name</label>
     <input type='text' id='node-input-name' placeholder='Name'>
@@ -386,7 +389,7 @@
   </div>
 </script>
 
-<script type='text/html' data-help-name='tulip-tables'>
+<script type="text/html" data-help-name="tulip-tables">
   <p>Reads & manipulates data in Tulip Tables using the Tulip Tables API.</p>
 
   <h3>Inputs</h3>
@@ -467,5 +470,3 @@
     </li>
   </ul>
 </script>
-
-

--- a/tulip_tables.js
+++ b/tulip_tables.js
@@ -2,7 +2,12 @@ module.exports = function (RED) {
   'use strict';
 
   const request = require('request');
+  const http = require('http');
   const https = require('https');
+  const httpLibs = {
+    http,
+    https,
+  }
   const tulipTables = require('./static/tulip_tables_common');
 
   // Tulip API node
@@ -12,7 +17,7 @@ module.exports = function (RED) {
     // Set node properties
     this.name = config.name;
     this.apiAuth = RED.nodes.getNode(config.apiAuth);
-    this.agent = new https.Agent({
+    this.agent = new httpLibs[apiAuth.protocol].Agent({
       keepAlive: config.keepAlive,
       keepAliveMsecs: config.keepAliveMsecs,
     });

--- a/tulip_tables.js
+++ b/tulip_tables.js
@@ -17,7 +17,7 @@ module.exports = function (RED) {
     // Set node properties
     this.name = config.name;
     this.apiAuth = RED.nodes.getNode(config.apiAuth);
-    this.agent = new httpLibs[apiAuth.protocol].Agent({
+    this.agent = new httpLibs[this.apiAuth.protocol].Agent({
       keepAlive: config.keepAlive,
       keepAliveMsecs: config.keepAliveMsecs,
     });

--- a/tulip_tables.js
+++ b/tulip_tables.js
@@ -1,13 +1,12 @@
 module.exports = function (RED) {
   'use strict';
 
-  const request = require('request');
   const http = require('http');
   const https = require('https');
   const httpLibs = {
     http,
     https,
-  }
+  };
   const tulipTables = require('./static/tulip_tables_common');
 
   // Tulip API node
@@ -17,11 +16,14 @@ module.exports = function (RED) {
     // Set node properties
     this.name = config.name;
     this.apiAuth = RED.nodes.getNode(config.apiAuth);
-    this.agent = new httpLibs[this.apiAuth.protocol].Agent({
+    this.config = config;
+
+    // Use http or https depending on the factory protocol
+    const httpLib = httpLibs[this.apiAuth.protocol];
+    this.agent = new httpLib.Agent({
       keepAlive: config.keepAlive,
       keepAliveMsecs: config.keepAliveMsecs,
     });
-    this.config = config;
     const node = this;
 
     const queryInfo = tulipTables.TABLE_QUERY_TYPES[config.queryType];
@@ -29,68 +31,116 @@ module.exports = function (RED) {
 
     // Handle node inputs
     node.on('input', function (msg, send, done) {
-      // Get all relevant parameters, overriding config value with msg if set
-      const pathParams = {};
-      const queryParams = {};
+      try {
+        // Get all relevant parameters, overriding config value with msg if set
+        const pathParams = {};
+        const queryParams = {};
 
-      for (const p of queryInfo.pathParams) {
-        pathParams[p] = getParamVal(p, msg);
-      }
-      for (const p of queryInfo.queryParams) {
-        queryParams[p] = getParamVal(p, msg);
-      }
+        for (const p of queryInfo.pathParams) {
+          pathParams[p] = getParamVal(p, msg);
+        }
+        for (const p of queryInfo.queryParams) {
+          queryParams[p] = getParamVal(p, msg);
+        }
 
-      // Create URL
-      const reqUrl = getApiUrl(
-        node.apiAuth.protocol,
-        node.apiAuth.hostname,
-        node.apiAuth.port,
-        pathParams,
-        queryParams,
-      );
+        // Create URL
+        const reqUrl = getApiUrl(
+          node.apiAuth.protocol,
+          node.apiAuth.hostname,
+          node.apiAuth.port,
+          pathParams,
+          queryParams
+        );
 
-      // Configure request with auth
-      const options = {
-        url: reqUrl,
-        method: queryInfo.method,
-        auth: {
-          user: node.apiAuth.credentials.apiKey,
-          pass: node.apiAuth.credentials.apiSecret,
-        },
-        agent: node.agent,
-      };
+        // Configure request with auth
+        const options = {
+          method: queryInfo.method,
+          auth: `${node.apiAuth.credentials.apiKey}:${node.apiAuth.credentials.apiSecret}`,
+          agent: node.agent,
+        };
 
-      // If a POST request, add the request body
-      if (hasBody) {
-        options.body = JSON.stringify(getParamVal('body', msg));
-        options.headers = getHeaders(msg);
-      } else {
-        options.headers = msg.headers;
-      }
+        // Make the http(s) request
+        const req = httpLib.request(reqUrl, options, handler(send, done));
+        setHeaders(req, msg.headers);
 
-      // Make the request
-      request(options, function (err, res, body) {
-        if (err) {
+        if (hasBody) {
+          // Send the message body
+          const rawBody = getParamVal('body', msg);
+          const body = JSON.stringify(rawBody);
+          req.write(body);
+        }
+
+        req.on('error', (err) => {
           done(err);
-        } else {
-          if (res.statusCode < 200 || res.statusCode >= 300) {
-            // Request returns error code
-            node.error(new Error(`Response status code ${res.statusCode}:` + `${res.body}`));
-          }
+        });
 
-          // Request went through, forward response as node output
-          const resBody = res.body == '' ? res.body : JSON.parse(res.body);
+        req.end();
+      } catch (err) {
+        // Catch unhandled errors so node-red doesn't crash
+        done(err);
+      }
+    });
+
+    // Returns a handler for the HTTP response that passes the body to `send`, and passes
+    // errors to onError
+    const handler = function (send, done) {
+      return (res) => {
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          // Request returns error code
+          node.error(new Error(`Response status code ${res.statusCode}`));
+        }
+
+        let body = '';
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+
+        // At the end of response, pass response body as msg.payload
+        res.on('end', () => {
+          const convertJSON =
+            res.headers['content-type'] &&
+            res.headers['content-type'].includes('application/json');
+
+          // if response is JSON, parse body as JSON
+          const payload = convertJSON ? JSON.parse(body) : body;
           const msg = {
             response: res,
-            payload: resBody,
+            payload,
           };
           send(msg);
           done();
-        }
-      });
-    });
+        });
+      };
+    };
 
-    function getApiUrl(protocol, hostname, port, pathParams, queryParams) {
+    const setHeaders = function (req, headers) {
+      if (headers) {
+        Object.entries(headers).forEach(([header, val]) => {
+          req.setHeader(header, val);
+        });
+      }
+
+      if (hasBody) {
+        // Set content-type to some form of application/json if not already
+        const oldContentType = req.getHeader('content-type');
+        if (oldContentType && !oldContentType.includes('application/json')) {
+          node.warn(
+            `Overriding header 'content-type'='${oldContentType}'; must be 'application/json'`
+          );
+          req.setHeader('content-type', 'application/json');
+        } else if (!oldContentType) {
+          req.setHeader('content-type', 'application/json');
+        }
+      }
+    };
+
+    const getApiUrl = function (
+      protocol,
+      hostname,
+      port,
+      pathParams,
+      queryParams
+    ) {
       // start with valid protocol & host
       const baseUrl = `${protocol}://${hostname}`;
       const url = new URL(baseUrl);
@@ -106,9 +156,9 @@ module.exports = function (RED) {
       }
 
       return url;
-    }
+    };
 
-    function getParamVal(p, msg) {
+    const getParamVal = function (p, msg) {
       const msgVal = msg[p];
       const configVal = node.config[p];
 
@@ -137,30 +187,13 @@ module.exports = function (RED) {
       } else {
         return undefined;
       }
-    }
-
-    /**
-     * Gets the headers for the Tulip API request. Uses the user-defined msg.headers,
-     * but overrides 'Content-Type' to 'application/json'.
-     */
-    function getHeaders(msg) {
-      // Default header for API request
-      const headers = msg.headers || {};
-
-      // Content-Type set by this node; overrides user value
-      if (headers['Content-Type']) {
-        node.warn(
-          `Overriding header 'Content-Type'='${headers['Content-Type']}'; must be 'application/json'`,
-        );
-      }
-      headers['Content-Type'] = 'application/json';
-      return headers;
-    }
+    };
   }
 
   // Register the node
   RED.nodes.registerType('tulip-tables', TablesNode);
 
+  // Host files in /static/ at /node-red-tulip-edge/js/ so they are accessible by browser code
   RED.httpAdmin.get('/node-red-tulip-edge/js/*', function (req, res) {
     const options = {
       root: __dirname + '/static/',

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,61 @@
+/**
+ * Makes an HTTP request to the designated endpoint with options. Passes on the HTTP response
+ * in an outgoing message.
+ * @param {Object} httpLib - http or https library, depending on which protocol to use
+ * @param {URL} endpoint - URL to send the request to
+ * @param {Object} options - options for the http(s) request
+ * @param {string} [body] - stringified JSON body
+ * @param {function} error - function to log errors
+ * @param {function} send - function to pass the outgoing message to.
+ * @param {function} done - function to call after the message has been sent
+ *
+ */
+const doHttpRequest = function (
+  httpLib,
+  endpoint,
+  options,
+  body,
+  error,
+  send,
+  done
+) {
+  const req = httpLib.request(endpoint, options, (res) => {
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      // Request returns error code
+      error(new Error(`Response status code ${res.statusCode}`));
+    }
+
+    let body = '';
+    res.on('data', (chunk) => {
+      body += chunk;
+    });
+
+    // At the end of response, pass response body as msg.payload
+    res.on('end', () => {
+      const convertJSON =
+        res.headers['content-type'] &&
+        res.headers['content-type'].includes('application/json');
+
+      // if response is JSON, parse body as JSON
+      const payload = convertJSON ? JSON.parse(body) : body;
+      const msg = {
+        response: res,
+        payload,
+      };
+      send(msg);
+      done();
+    });
+  });
+
+  if (body) {
+    req.write(body);
+  }
+  req.on('error', (err) => {
+    done(err);
+  });
+  req.end();
+};
+
+module.exports = {
+  doHttpRequest,
+};


### PR DESCRIPTION
Removes deprecated package `request` as a dependency. Refactors code to use `http`/`https` packages instead. Separates code to do an HTTP request into a common utils file. The other changes here are just formatting cleanup.

# Test Plan
Here's an example test flow that you should set up to point to a Tulip table and Tulip machine attribute on your factory instance, using an API bot with all permissions (or at least table read/write and machine attribute write). Specifically, you'll need to:
- [ ] in your node-red installation (local, not Tulip edge device), add dependency to package.json: `"@tulip/node-red-tulip-api": "git+ssh://git@github.com:tulip/node-red-tulip-api.git#kathy.remove-request"`
- [ ] rerun `npm install`
- [ ] check in node-red palette that version of node-red-tulip-api is 0.2.1
- [ ] copy-paste the following flow into node-red
- [ ] fill in the bot credentials for the API auth node (click into one of the tulip nodes, edit the existing api auth - it is shared between all the tulip nodes)
- [ ] copy-paste the device/machine ids for an integer machine attribute 
- [ ] deploy flow
- [ ] run the first inject; check that the timestamp shows up in factory under the designated machine attribute
- [ ] run the second inject, should print 0 in debug console & a new table should show up on your factory instance ("my table")

```
[{"id":"60040c12.ce99b4","type":"tulip-machine-attribute","z":"c0f9d2ab.33f02","name":"tulip-machine-attribute","apiAuth":"825e6b19.72cb38","keepAlive":true,"keepAliveMsecs":10000,"deviceInfo":"{\"machineId\":\"xG9uMBp8yuDb3eGik\", \"attributeId\":\"wWhCvj6trj5WKxLZv\"}","payloadSource":"payload","payloadType":"msg","x":360,"y":80,"wires":[[]]},{"id":"c44104c8.8d51c8","type":"tulip-tables","z":"c0f9d2ab.33f02","name":"tulip-tables","apiAuth":"825e6b19.72cb38","keepAlive":true,"keepAliveMsecs":10000,"queryType":"1","tableId":"","queryId":"","aggregationId":"","recordId":"","fieldId":"","sortBy":"_sequenceNumber","sortByFieldId":"","sortDir":"asc","function":"sum","filterAggregator":"all","limit":10,"offset":0,"includeDeleted":false,"includeTotalCount":false,"allowRecordsInUse":false,"field":[],"filters":[],"sortOptions":[],"body":"{\"label\":\"my table\",\"description\":\"a table\",\"columns\":[{\"name\":\"a_column\",\"label\":\"a column\",\"description\":\"a column?\",\"dataType\":{\"type\":\"integer\"},\"hidden\":false,\"unique\":false}]}","x":350,"y":200,"wires":[["5924db0b.043834","e6dc3fe8.d8a2f"]]},{"id":"72eccfad.e03df","type":"inject","z":"c0f9d2ab.33f02","name":"","props":[{"p":"payload"}],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","payload":"","payloadType":"date","x":140,"y":80,"wires":[["60040c12.ce99b4"]]},{"id":"5164a0c4.e4798","type":"inject","z":"c0f9d2ab.33f02","name":"Create table","props":[],"repeat":"","crontab":"","once":false,"onceDelay":0.1,"topic":"","x":150,"y":200,"wires":[["c44104c8.8d51c8"]]},{"id":"5924db0b.043834","type":"debug","z":"c0f9d2ab.33f02","name":"","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"payload","targetType":"msg","statusVal":"","statusType":"auto","x":550,"y":160,"wires":[]},{"id":"e6dc3fe8.d8a2f","type":"change","z":"c0f9d2ab.33f02","name":"","rules":[{"t":"set","p":"tableId","pt":"msg","to":"payload.id","tot":"msg"},{"t":"set","p":"payload","pt":"msg","to":"{}","tot":"json"}],"action":"","property":"","from":"","to":"","reg":false,"x":560,"y":200,"wires":[["5696e130.71bbf"]]},{"id":"5696e130.71bbf","type":"tulip-tables","z":"c0f9d2ab.33f02","name":"tulip-tables","apiAuth":"825e6b19.72cb38","keepAlive":true,"keepAliveMsecs":10000,"queryType":"7","tableId":"","queryId":"","aggregationId":"","recordId":"","fieldId":"","sortBy":"_sequenceNumber","sortByFieldId":"","sortDir":"asc","function":"sum","filterAggregator":"all","limit":10,"offset":0,"includeDeleted":false,"includeTotalCount":false,"allowRecordsInUse":false,"field":[],"filters":[],"sortOptions":[],"body":"{}","x":750,"y":200,"wires":[["89792e96.95fdf"]]},{"id":"89792e96.95fdf","type":"debug","z":"c0f9d2ab.33f02","name":"","active":true,"tosidebar":true,"console":false,"tostatus":false,"complete":"false","statusVal":"","statusType":"auto","x":940,"y":200,"wires":[]},{"id":"825e6b19.72cb38","type":"tulip-api-auth","name":"tulip-api-auth","protocol":"https","hostname":"kathyc.tulip.co","port":""}]
```