### PR TITLE
Add new Tables API endpoints

### DIFF
--- a/static/tulip_tables_common.js
+++ b/static/tulip_tables_common.js
@@ -243,7 +243,72 @@
       pathConstructor: function(p) {
         return `/tables/${p.tableId}/aggregation/${p.aggregationId}`;
       }
-    }
+    },
+    {
+      text: 'Increment or decrement a field in a Tulip Table record',
+      method: 'PATCH',
+      pathParams: [
+        'tableId',
+        'recordId'
+      ],
+      queryParams: [],
+      pathConstructor: function(p) {
+        return `/tables/${p.tableId}/records/${p.recordId}/increment`;
+      }
+    },
+    {
+      text: 'Link records',
+      method: 'PUT',
+      pathParams: [
+        'linkId'
+      ],
+      queryParams: [],
+      pathConstructor: function(p) {
+        return `/tableLinks/${p.linkId}/link`;
+      }
+    },
+    {
+      text: 'Unlink records',
+      method: 'PUT',
+      pathParams: [
+        'linkId'
+      ],
+      queryParams: [],
+      pathConstructor: function(p) {
+        return `/tableLinks/${p.linkId}/link`;
+      }
+    },
+    {
+      text: 'Create a table link relationship',
+      method: 'POST',
+      pathParams: [],
+      queryParams: [],
+      pathConstructor: function(p) {
+        return `/tableLinks`;
+      }
+    },
+    {
+      text: 'Fetch link information',
+      method: 'GET',
+      pathParams: [
+        'linkId'
+      ],
+      queryParams: [],
+      pathConstructor: function(p) {
+        return `/tableLinks/${p.linkId}`;
+      }
+    },
+    {
+      text: 'Update the column labels for link',
+      method: 'PUT',
+      pathParams: [
+        'linkId'
+      ],
+      queryParams: [],
+      pathConstructor: function(p) {
+        return `/tableLinks/${p.linkId}`;
+      }
+    },
   ];
 
   exports.FUNCTION_TYPES = [

--- a/tulip_tables.html
+++ b/tulip_tables.html
@@ -27,6 +27,7 @@
       aggregationId: { value: '' },
       recordId: { value: '' },
       fieldId: { value: '' },
+      linkId: { value: '' },
       sortBy: { value: '_sequenceNumber' },
       sortByFieldId: { value: '' },
       sortDir: { value: 'asc' },
@@ -313,6 +314,10 @@
   <div class='form-row' id='div-node-input-fieldId' hidden>
     <label for='node-input-fieldId'> Field ID</label>
     <input type='text' id='node-input-fieldId' placeholder='fieldId'>
+  </div>
+  <div class='form-row' id='div-node-input-linkId' hidden>
+    <label for='node-input-linkId'> Link ID</label>
+    <input type='text' id='node-input-linkId' placeholder='linkId'>
   </div>
   <div class='form-row' id='div-node-input-function' hidden>
     <label for='node-input-function'> Aggregation Function</label>

--- a/tulip_tables.js
+++ b/tulip_tables.js
@@ -28,7 +28,7 @@ module.exports = function (RED) {
     const node = this;
 
     const queryInfo = tulipTables.TABLE_QUERY_TYPES[config.queryType];
-    const hasBody = queryInfo.method == 'POST' || queryInfo.method == 'PUT';
+    const hasBody = queryInfo.method == 'POST' || queryInfo.method == 'PUT' || queryInfo.method == 'PATCH';
 
     // Handle node inputs
     node.on('input', function (msg, send, done) {


### PR DESCRIPTION
Adds newly-publishes Tables API endpoints to the `tulip-tables` node.

New endpoints are:
- Increment/decrement record
- Link record
- Unlink record
- Create table link relationship
- Fetch link information
- Update link column labels